### PR TITLE
Add the possibility of using transformers in Sentiment Analysis

### DIFF
--- a/module3/s4_sentiment.ipynb
+++ b/module3/s4_sentiment.ipynb
@@ -4,21 +4,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Sentiment analysis avec Textblob-FR"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Documentation: https://textblob.readthedocs.io/en/dev/"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Imports"
+    "# Sentiment analysis \n",
+    "\n",
+    "## 1. Textblob-FR\n",
+    "\n",
+    "Documentation: https://textblob.readthedocs.io/en/dev/\n",
+    "\n",
+    "### Imports"
    ]
   },
   {
@@ -36,7 +28,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Fonction"
+    "### Création d'une fonction `get_sentiment`"
    ]
   },
   {
@@ -69,7 +61,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Analyser le sentiment d'une phrase"
+    "### Analyser le sentiment d'une phrase"
    ]
   },
   {
@@ -80,7 +72,7 @@
    },
    "outputs": [],
    "source": [
-    "get_sentiment(\"Ce journal parle de la coupe du monde.\")"
+    "get_sentiment(\"Ce journal est vraiment super intéressant.\")"
    ]
   },
   {
@@ -92,6 +84,79 @@
    "outputs": [],
    "source": [
     "get_sentiment(\"Cette phrase est négative et je ne suis pas content !\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Utilisation de transformers \n",
+    "\n",
+    "Documentation: https://github.com/TheophileBlard/french-sentiment-analysis-with-bert\n",
+    "\n",
+    "**!!** Si le code ne tourne pas sur votre machine, vous pouvez le tester directement sur Google Colab en utilisant [ce lien](https://colab.research.google.com/github/TheophileBlard/french-sentiment-analysis-with-bert/blob/master/colab/french_sentiment_analysis_with_bert.ipynb) **!!**\n",
+    "\n",
+    "Le modèle peut également être testé en ligne sur [HuggingFace](https://huggingface.co/tblard/tf-allocine)\n",
+    "\n",
+    "### Installation des librairies et imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install tensorflow\n",
+    "!pip install sentencepiece\n",
+    "!pip install transformers\n",
+    "\n",
+    "from transformers import AutoTokenizer, TFAutoModelForSequenceClassification\n",
+    "from transformers import pipeline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Chargement du modèle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tokenizer = AutoTokenizer.from_pretrained(\"tblard/tf-allocine\", use_pt=True)\n",
+    "model = TFAutoModelForSequenceClassification.from_pretrained(\"tblard/tf-allocine\")\n",
+    "\n",
+    "sentiment_analyser = pipeline('sentiment-analysis', model=model, tokenizer=tokenizer)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Analyser le sentiment d'une phrase"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sentiment_analyser(\"Ce journal est vraiment super intéressant.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sentiment_analyser(\"Cette phrase est négative et je ne suis pas content !\")"
    ]
   }
  ],

--- a/module3/s4_sentiment.ipynb
+++ b/module3/s4_sentiment.ipynb
@@ -90,7 +90,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 2. Utilisation de transformers \n",
+    "## 2. Utilisation de transformers\n",
     "\n",
     "Documentation: https://github.com/TheophileBlard/french-sentiment-analysis-with-bert\n",
     "\n",


### PR DESCRIPTION
I have improved the notebook of Sentiment analysis by adding the possibility of using transformers

Concretely, I let Textblob there and I have added this model : https://huggingface.co/tblard (as suggested by @madewild )

If the code with transformers is not working, they can directly test it on Google Colab: https://colab.research.google.com/github/TheophileBlard/french-sentiment-analysis-with-bert/blob/master/colab/french_sentiment_analysis_with_bert.ipynb

With those two methods we will be able to compare performances of both models.
