### PR TITLE
add encoding when writing to file to avoid errors on windows

### DIFF
--- a/module2/s1_convert.ipynb
+++ b/module2/s1_convert.ipynb
@@ -131,7 +131,7 @@
     "        \n",
     "    pdf_file.close()\n",
     "\n",
-    "    with open(os.path.join(txt_path, f'{os.path.splitext(pdf)[0]}.txt'), 'w') as output_file:\n",
+    "    with open(os.path.join(txt_path, f'{os.path.splitext(pdf)[0]}.txt'), 'w', encoding=\"utf-8\") as output_file:\n",
     "        output_file.write(text)"
    ]
   },


### PR DESCRIPTION
Add encoding when writing to files solving this [issue](https://github.com/madewild/tac/issues/92#issue-3466526239)