### PR TITLE
change from textract to textract-py3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ beautifulsoup4==4.8.2
 lxml==5.3.0
 textblob==0.17.1
 pypdf2==3.0.1
-textract==1.6.5
+textract-py3==2.1.1
 spacy==3.5.2
 pydantic==1.10.13
 textblob_fr==0.2.0


### PR DESCRIPTION
Avoid dependencies issues for textract using the [maintained fork](https://pypi.org/project/textract-py3/) from the original repository
